### PR TITLE
Introduce TimeSecond#to_i

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ t.hm     #=> '02:01'
 
 # New from String
 t = TimeSecond.parse('02:01:39')
+t.to_i #=> 7299
 ```
 
 ## Contributing

--- a/lib/time_second.rb
+++ b/lib/time_second.rb
@@ -1,6 +1,12 @@
+require 'forwardable'
+
 # Integer as a Second
 class TimeSecond
   VERSION = '0.1.0'.freeze
+
+  extend Forwardable
+
+  def_delegators :@time, :to_i
 
   # Parse 'HH:MM:SS' format string and return its object
   #


### PR DESCRIPTION
## Summary
Introduce `TimeSecond#to_i` method using `Forwardable`.

## Usage

```ruby
irb(main):003:0> TimeSecond.new(60 * 60).to_i
=> 3600
```